### PR TITLE
[IMPROVEMENT] Use xcode PROJECT_DIR variable rather than a relative path

### DIFF
--- a/BrcmPatchRAM.xcodeproj/project.pbxproj
+++ b/BrcmPatchRAM.xcodeproj/project.pbxproj
@@ -713,7 +713,7 @@
 			buildConfigurationList = 84CDEE081BB3CA2200238DD1 /* Build configuration list for PBXLegacyTarget "Prebuild" */;
 			buildPhases = (
 			);
-			buildToolPath = ./generate_firmware_data.sh;
+			buildToolPath = "$(PROJECT_DIR)/generate_firmware_data.sh";
 			buildWorkingDirectory = "";
 			dependencies = (
 			);


### PR DESCRIPTION
Using the env variable rather than a simple relative path for the prebuild target action allows tools like [Hackintool](https://github.com/headkaze/Hackintool) to correctly leverage command line params for build automation in custom directories.