### PR TITLE
Replicate Linux's btbcm.c initialisation process

### DIFF
--- a/BrcmPatchRAM/BrcmPatchRAM.h
+++ b/BrcmPatchRAM/BrcmPatchRAM.h
@@ -43,6 +43,7 @@
 enum DeviceState
 {
     kUnknown,
+    kPreInitialize,
     kInitialize,
     kFirmwareVersion,
     kMiniDriverComplete,
@@ -169,7 +170,6 @@ private:
     void printDeviceInfo();
     int getDeviceStatus();
     
-    bool resetDevice();
     bool setConfiguration(int configurationIndex);
     
     bool findInterface(USBInterfaceShim* interface);


### PR DESCRIPTION
It solves the cold boot issue. In my case at least. The changes are:

I use the hci command for initial reset instead of ```mDevice.resetDevice()``` and I do delay after both the first and the second resets as it is in this function: https://github.com/torvalds/linux/blob/master/drivers/bluetooth/btbcm.c#L220

Also I've hardcoded 250 msecs for the delay after bulk writes according to this line in the Linux driver 
https://github.com/torvalds/linux/blob/master/drivers/bluetooth/btbcm.c#L213

So with ```bpr_handshake=0``` it behaves exactly like the Linux driver. I tested several times on my machine and it connects after cold reboots and powering off BT devices.
