### PR TITLE
add Laird BT851 Bluetooth 5.0 USB dongle

### DIFF
--- a/BrcmBluetoothInjector-Info.plist
+++ b/BrcmBluetoothInjector-Info.plist
@@ -2,40 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>BuildMachineOSBuild</key>
-	<string>19F101</string>
 	<key>CFBundleIdentifier</key>
-	<string>as.acidanthera.injector.BrcmBluetoothInjector</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>BrcmBluetoothInjector</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.5</string>
+	<string>${CURRENT_PROJECT_VERSION}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleSupportedPlatforms</key>
-	<array>
-		<string>MacOSX</string>
-	</array>
 	<key>CFBundleVersion</key>
-	<string>2.5.5</string>
-	<key>DTCompiler</key>
-	<string>com.apple.compilers.llvm.clang.1_0</string>
-	<key>DTPlatformBuild</key>
-	<string>11E708</string>
-	<key>DTPlatformVersion</key>
-	<string>GM</string>
-	<key>DTSDKBuild</key>
-	<string>19G68</string>
-	<key>DTSDKName</key>
-	<string>macosx10.15</string>
-	<key>DTXcode</key>
-	<string>1160</string>
-	<key>DTXcodeBuild</key>
-	<string>11E708</string>
+	<string>${CURRENT_PROJECT_VERSION}</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>04b4_f901</key>
@@ -1464,8 +1444,6 @@
 			<integer>16700</integer>
 		</dict>
 	</dict>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.8</string>
 	<key>OSBundleRequired</key>
 	<string>Root</string>
 </dict>

--- a/BrcmBluetoothInjector-Info.plist
+++ b/BrcmBluetoothInjector-Info.plist
@@ -2,22 +2,57 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BuildMachineOSBuild</key>
+	<string>19F101</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>as.acidanthera.injector.BrcmBluetoothInjector</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>BrcmBluetoothInjector</string>
 	<key>CFBundlePackageType</key>
 	<string>KEXT</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
+	<string>2.5.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
 	<key>CFBundleVersion</key>
-	<string>${CURRENT_PROJECT_VERSION}</string>
+	<string>2.5.5</string>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>11E708</string>
+	<key>DTPlatformVersion</key>
+	<string>GM</string>
+	<key>DTSDKBuild</key>
+	<string>19G68</string>
+	<key>DTSDKName</key>
+	<string>macosx10.15</string>
+	<key>DTXcode</key>
+	<string>1160</string>
+	<key>DTXcodeBuild</key>
+	<string>11E708</string>
 	<key>IOKitPersonalities</key>
 	<dict>
+		<key>04b4_f901</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOClass</key>
+			<string>BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOProbeScore</key>
+			<integer>3000</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>63745</integer>
+			<key>idVendor</key>
+			<integer>1204</integer>
+		</dict>
 		<key>03f0_231d no firmware</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
@@ -1429,6 +1464,8 @@
 			<integer>16700</integer>
 		</dict>
 	</dict>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.8</string>
 	<key>OSBundleRequired</key>
 	<string>Root</string>
 </dict>


### PR DESCRIPTION
There is a very affordable dongle described here:
https://www.tonymacx86.com/threads/how-to-bluetooth-5-0-usb-dongle-guide.287115/post-2100201

It works OOB for some but not all. Adding to BrcmBluetoothInjector is a simple fix. It doesn't even need the RamPatch.