### PR TITLE
Add Fenvi BCM94352Z identifiers

### DIFF
--- a/BrcmBluetoothInjector.kext/Contents/Info.plist
+++ b/BrcmBluetoothInjector.kext/Contents/Info.plist
@@ -1030,6 +1030,21 @@
 			<key>idVendor</key>
 			<integer>2652</integer>
 		</dict>
+		<key>0a5c_828d</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOClass</key>
+			<string>BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOProbeScore</key>
+			<integer>3000</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBHostDevice</string>
+			<key>idProduct</key>
+			<integer>33421</integer>
+			<key>idVendor</key>
+			<integer>2652</integer>
+		</dict>
 		<key>0b05_178a</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/BrcmBluetoothInjectorLegacy.kext/Contents/Info.plist
+++ b/BrcmBluetoothInjectorLegacy.kext/Contents/Info.plist
@@ -1030,6 +1030,21 @@
 			<key>idVendor</key>
 			<integer>2652</integer>
 		</dict>
+		<key>0a5c_828d</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.apple.iokit.BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOClass</key>
+			<string>BroadcomBluetoothHostControllerUSBTransport</string>
+			<key>IOProbeScore</key>
+			<integer>3000</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>33421</integer>
+			<key>idVendor</key>
+			<integer>2652</integer>
+		</dict>
 		<key>0b05_178a</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ BrcmBluetoothInjector supported devices:
   * ``[0a5c:6417]`` Zebra 4352
   * ``[0a5c:6418]`` HP Brook 2x2ac
   * ``[0a5c:7460]`` 20703A1 RAM download
+  * ``[0a5c:828d]`` Fenvi BCM94352Z
   * ``[0b05:178a]`` BCM2070 - BCM943224HMB, BCM943225HMB Combo
   * ``[0b05:17b5]`` Asus 43228+20702A1 combo
   * ``[0b05:17cb]`` 20702 standalone
@@ -207,6 +208,7 @@ Tested PatchRAM devices:
   * ``[0a5c:22be]`` Broadcom BCM20702 Bluetooth 4.0 USB Device
   * ``[0a5c:6410]`` Dell Wireless 1830 Bluetooth 4.1 LE
   * ``[0a5c:6412]`` Dell Wireless 1820 Bluetooth 4.1 LE
+  * ``[0a5c:828d]`` Fenvi BCM94352Z
   * ``[0b05:17cb]`` Asus BT-400 (20702 stand-alone) *
   * ``[0b05:17cf]`` Asus (4352/20702A1 combo) *
   * ``[0b05:180a]`` Azurewave (4360/20702 combo)

--- a/README_CN.md
+++ b/README_CN.md
@@ -54,7 +54,7 @@ IOCatalogue::addDrivers, IOCatalogue::removeDrivers and IOCatalogue::startMatchi
 
 请勿在此kext上使用`BrcmPatchRAM`或`BrcmPatchRAM2`。
 
-`BrcmBluetoothInjector` supported devices:
+`BrcmBluetoothInjector` 支持的设备:
 
   * ``[0489:e032]`` 20702 E032 Combo
   * ``[0489:e042]`` 20702A1 Lenovo China standalone
@@ -124,6 +124,7 @@ IOCatalogue::addDrivers, IOCatalogue::removeDrivers and IOCatalogue::startMatchi
   * ``[0a5c:6417]`` Zebra 4352
   * ``[0a5c:6418]`` HP Brook 2x2ac
   * ``[0a5c:7460]`` 20703A1 RAM download
+  * ``[0a5c:828d]`` Fenvi BCM94352Z
   * ``[0b05:17b5]`` Asus 43228+20702A1 combo
   * ``[0b05:17cb]`` 20702 standalone
   * ``[0b05:17cf]`` Asus 4352_20702A1 combo
@@ -200,6 +201,7 @@ IOCatalogue::addDrivers, IOCatalogue::removeDrivers and IOCatalogue::startMatchi
   * ``[0a5c:22be]`` Broadcom BCM20702 Bluetooth 4.0 USB Device
   * ``[0a5c:6410]`` Dell Wireless 1830 Bluetooth 4.1 LE
   * ``[0a5c:6412]`` Dell Wireless 1820 Bluetooth 4.1 LE
+  * ``[0a5c:828d]`` Fenvi BCM94352Z
   * ``[0b05:17cb]`` Asus BT-400 (20702 stand-alone) *
   * ``[0b05:17cf]`` Asus (4352/20702A1 combo) *
   * ``[0b05:180a]`` Azurewave (4360/20702 combo)


### PR DESCRIPTION
Adding another vendor/product ID pair which suits and works with [my Broadcom card](https://detail.tmall.com/item.htm?id=610509493715). After applying the Kext which is presented in this PR, my AirDrop no longer stops working after being woken up.

Proof of vendor/product IDs:
![image](https://user-images.githubusercontent.com/3624869/119996107-e9cd2200-c000-11eb-8224-7b33fa66a433.png)
