### PR TITLE
Add board-id patches for BlueTool and bluetoothd to overcome the hardcoded transport type

### DIFF
--- a/BrcmPatchRAM/BlueToolFixup.cpp
+++ b/BrcmPatchRAM/BlueToolFixup.cpp
@@ -37,9 +37,6 @@ bool BlueToolFixup::start(IOService *provider) {
         return false;
     }
     setProperty("VersionInfo", kextVersion);
-    setName("bluetooth");
-    uint8_t bytes[] {0x00, 0x00, 0x00, 0x00};
-    setProperty("transport-encoding", bytes, sizeof(bytes));
     registerService();
     
     return true;
@@ -134,7 +131,7 @@ static void pluginStart() {
             auto boardId = BaseDeviceInfo::get().boardIdentifier;
             shouldPatchBoardId = strlen(boardId) + 1 == kBoardIdSize;
             if (shouldPatchBoardId)
-                for (int i = 0; i < sizeof(boardIdsWithUSBBluetooth) / sizeof(boardIdsWithUSBBluetooth[0]); i++)
+                for (size_t i = 0; i < arrsize(boardIdsWithUSBBluetooth); i++)
                     if (strcmp(boardIdsWithUSBBluetooth[i], boardId) == 0) {
                         shouldPatchBoardId = false;
                         break;


### PR DESCRIPTION
This patch replaces the board-id of MacBookAir7,2 in `bluetoothd` and `BlueTool` with the currently used board-id, so that the transport types shows as USB and Bluetooth works, like on the MacBookAir7,2 model. References acidanthera/bugtracker#1821. I'm currently using this patch to make Bluetooth work on MacBookPro15,4 model.

TODO: make a list of models that already use USB and don't use the patch on these models.