### PR TITLE
BlueToolFixup: Add Skip Address Check patch for 13.0 Beta 1 and newer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ BrcmPatchRAM Changelog
 ======================
 #### v2.6.3
 - Added constants for macOS 13 support
+- Fixed Skip Address Check patch for 13.0 Beta 1 and newer
 
 #### v2.6.2
 - Added Skip Address Check patch for 12.4 Beta 3 and newer (thx @khronokernel)


### PR DESCRIPTION
This fixes https://github.com/acidanthera/BrcmPatchRAM/pull/20 that is broken on 13.0 Beta 1 due to the change of hex sequences. Requires https://github.com/acidanthera/Lilu/pull/83 to test.