### PR TITLE
Update README-Mac.md for macOS 10.15 and later

### DIFF
--- a/README-Mac.md
+++ b/README-Mac.md
@@ -15,11 +15,18 @@ sudo cp -R ~/Downloads/BrcmFirmwareRepo.kext /System/Library/Extensions
 sudo touch /System/Library/Extensions
 ```
 
-Or for 10.11 and later, to /Library/Extensions:
+For macOS 10.11 to 10.14, to /Library/Extensions:
 ```
 sudo cp -R ~/Downloads/BrcmPatchRAM2.kext /Library/Extensions
 sudo cp -R ~/Downloads/BrcmFirmwareRepo.kext /Library/Extensions
-sudo touch /System/Library/Extensions
+sudo touch /Library/Extensions
+```
+
+For macOS 10.15 and later, to /Library/Extensions:
+```
+sudo cp -R ~/Downloads/BrcmPatchRAM2.kext /Library/Extensions
+sudo cp -R ~/Downloads/BrcmFirmwareRepo.kext /Library/Extensions
+sudo touch /Library/Extensions
 ```
 
 Wait about a minute before rebooting the Mac again.


### PR DESCRIPTION
The README for Mac hasn't been updated since September 2019. macOS 10.15 was released in October 2019, that's why the README is currently out-of-date.