### PR TITLE
Update BrcmPatchRAM3.cpp

### DIFF
--- a/BrcmPatchRAM/BrcmPatchRAM3.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM3.cpp
@@ -818,8 +818,9 @@ bool BrcmPatchRAM::performUpgrade()
                 IOSleep(mInitialDelay);
                 
                 // Write first instruction to trigger response
+                // changed the bulkwrite to hciCommand for BigSur support
                 if ((data = OSDynamicCast(OSData, iterator->getNextObject())))
-                    bulkWrite(data->getBytesNoCopy(), data->getLength());
+                    hciCommand(data->getBytesNoCopy(), data->getLength());
                 break;
                 
             case kInstructionWrite:


### PR DESCRIPTION
changed the bulkwrite to hciCommand for BigSur support @ line 822 and added comment Thanks to lalithkota @ TonymacX86: 
https://www.tonymacx86.com/threads/bluetooth-brcmpatchram-problems-bcm43142a0-stuck-in-minidriver-complete-state-oc-0-6-4-big-sur-11-1.308497/