### PR TITLE
Update BrcmPatchRAM3.cpp

### DIFF
--- a/BrcmPatchRAM/BrcmPatchRAM3.cpp
+++ b/BrcmPatchRAM/BrcmPatchRAM3.cpp
@@ -819,7 +819,8 @@ bool BrcmPatchRAM::performUpgrade()
                 
                 // Write first instruction to trigger response
                 if ((data = OSDynamicCast(OSData, iterator->getNextObject())))
-                    bulkWrite(data->getBytesNoCopy(), data->getLength());
+                //changed from bulkWrite for BigSur support
+                hciCommand((void*)(data->getBytesNoCopy()), data->getLength());
                 break;
                 
             case kInstructionWrite:
@@ -830,7 +831,8 @@ bool BrcmPatchRAM::performUpgrade()
                 }
                 
                 if ((data = OSDynamicCast(OSData, iterator->getNextObject()))) {
-                    bulkWrite(data->getBytesNoCopy(), data->getLength());
+                    //changed from bulkWrite for BigSur support
+                    hciCommand((void*)(data->getBytesNoCopy()), data->getLength());                    
                 } else {
                     // Firmware data fully written
                     if (hciCommand(&HCI_VSC_END_OF_RECORD, sizeof(HCI_VSC_END_OF_RECORD)) != kIOReturnSuccess) {


### PR DESCRIPTION
changed from bulkWrite for BigSur support @line 822,823 and 834,835 thanks to lalithkota @ tonymakX86:
https://www.tonymacx86.com/threads/bluetooth-brcmpatchram-problems-bcm43142a0-stuck-in-minidriver-complete-state-oc-0-6-4-big-sur-11-1.308497/