### PR TITLE
BlueToolFixup: Allow board ID patching for some legacy systems

### DIFF
--- a/BrcmPatchRAM/BlueToolFixup.cpp
+++ b/BrcmPatchRAM/BlueToolFixup.cpp
@@ -113,6 +113,7 @@ static bool shouldPatchBoardId = false;
 static bool shouldPatchAddress = false;
 
 static const size_t kBoardIdSize = sizeof("Mac-F60DEB81FF30ACF6");
+static const size_t kBoardIdSizeLegacy = sizeof("Mac-F22586C8");
 
 static const char boardIdsWithUSBBluetooth[][kBoardIdSize] = {
     "Mac-F60DEB81FF30ACF6",
@@ -189,7 +190,8 @@ static void pluginStart() {
     if (getKernelVersion() >= KernelVersion::Monterey) {
         lilu.onPatcherLoadForce([](void *user, KernelPatcher &patcher) {
             auto boardId = BaseDeviceInfo::get().boardIdentifier;
-            shouldPatchBoardId = strlen(boardId) + 1 == kBoardIdSize;
+            auto boardIdSize = strlen(boardId) + 1;
+            shouldPatchBoardId = boardIdSize == kBoardIdSize || boardIdSize == kBoardIdSizeLegacy;
             if (shouldPatchBoardId)
                 for (size_t i = 0; i < arrsize(boardIdsWithUSBBluetooth); i++)
                     if (strcmp(boardIdsWithUSBBluetooth[i], boardId) == 0) {

--- a/BrcmPatchRAM/BlueToolFixup.cpp
+++ b/BrcmPatchRAM/BlueToolFixup.cpp
@@ -112,8 +112,8 @@ static const uint8_t kBadChipsetCheckPatched[] =
 static bool shouldPatchBoardId = false;
 static bool shouldPatchAddress = false;
 
-static const size_t kBoardIdSize = sizeof("Mac-F60DEB81FF30ACF6");
-static const size_t kBoardIdSizeLegacy = sizeof("Mac-F22586C8");
+static constexpr size_t kBoardIdSize = sizeof("Mac-F60DEB81FF30ACF6");
+static constexpr size_t kBoardIdSizeLegacy = sizeof("Mac-F22586C8");
 
 static const char boardIdsWithUSBBluetooth[][kBoardIdSize] = {
     "Mac-F60DEB81FF30ACF6",


### PR DESCRIPTION
This enables board ID patching for systems which use old SMBIOSes with short board IDs. Fixes Bluetooth on my system (`MacBookPro6,2` hackintosh using OpenCore and OCLP, macOS 13.2.1, with a BCM94352HMB card).