### PR TITLE
BlueToolFixup: Add another Vendor callback patch to enable Bluetooth turn on/off after power cycle which is needed from Ventura 13.4.

### DIFF
--- a/BrcmPatchRAM/BlueToolFixup.cpp
+++ b/BrcmPatchRAM/BlueToolFixup.cpp
@@ -123,6 +123,22 @@ static const uint8_t kBadChipsetCheckPatched13_3[] =
     0x90, 0x90
 };
 
+static const uint8_t kSkipInternalControllerNVRAMCheck13_3[] =
+{
+    0x41, 0x80, 0xF7, 0x01, // xor     r15b, 1
+    0x75, 0x27,             // jnz     short
+    0x84, 0xDB,             // test    bl, bl
+    0x75, 0x23              // jnz     short
+};
+
+static const uint8_t kSkipInternalControllerNVRAMCheckPatched13_3[] =
+{
+    0x90, 0x90, 0x90, 0x90,
+    0x90, 0x90,
+    0x90, 0x90,
+    0x90, 0x90
+};
+
 static bool shouldPatchBoardId = false;
 static bool shouldPatchAddress = false;
 
@@ -188,6 +204,7 @@ static void patched_cs_validate_page(vnode_t vp, memory_object_t pager, memory_o
             searchAndPatch(data, PAGE_SIZE, path, kVendorCheckOriginal, kVendorCheckPatched);
             searchAndPatch(data, PAGE_SIZE, path, kBadChipsetCheckOriginal, kBadChipsetCheckPatched);
             searchAndPatch(data, PAGE_SIZE, path, kBadChipsetCheckOriginal13_3, kBadChipsetCheckPatched13_3);
+            searchAndPatch(data, PAGE_SIZE, path, kSkipInternalControllerNVRAMCheck13_3, kSkipInternalControllerNVRAMCheckPatched13_3);
             if (shouldPatchBoardId)
                 searchAndPatch(data, PAGE_SIZE, path, boardIdsWithUSBBluetooth[0], kBoardIdSize, BaseDeviceInfo::get().boardIdentifier, kBoardIdSize);
             if (shouldPatchAddress)

--- a/BrcmPatchRAM/BlueToolFixup.cpp
+++ b/BrcmPatchRAM/BlueToolFixup.cpp
@@ -109,6 +109,20 @@ static const uint8_t kBadChipsetCheckPatched[] =
     0xEB                     // jmp short
 };
 
+static const uint8_t kBadChipsetCheckOriginal13_3[] =
+{
+    0x81, 0xF9,              // cmp ecx
+    0x9E, 0x0F, 0x00, 0x00,  // int 3998
+    0x77, 0x1A               // ja short
+};
+
+static const uint8_t kBadChipsetCheckPatched13_3[] =
+{
+    0x90, 0x90,
+    0x90, 0x90, 0x90, 0x90,
+    0x90, 0x90
+};
+
 static bool shouldPatchBoardId = false;
 static bool shouldPatchAddress = false;
 
@@ -173,6 +187,7 @@ static void patched_cs_validate_page(vnode_t vp, memory_object_t pager, memory_o
         else if (strcmp(path + dirLength, "bluetoothd") == 0) {
             searchAndPatch(data, PAGE_SIZE, path, kVendorCheckOriginal, kVendorCheckPatched);
             searchAndPatch(data, PAGE_SIZE, path, kBadChipsetCheckOriginal, kBadChipsetCheckPatched);
+            searchAndPatch(data, PAGE_SIZE, path, kBadChipsetCheckOriginal13_3, kBadChipsetCheckPatched13_3);
             if (shouldPatchBoardId)
                 searchAndPatch(data, PAGE_SIZE, path, boardIdsWithUSBBluetooth[0], kBoardIdSize, BaseDeviceInfo::get().boardIdentifier, kBoardIdSize);
             if (shouldPatchAddress)


### PR DESCRIPTION
Hi,
This is a further fix patch for the same cause of problem. Here is the history link:
#18 

Apple's changes broke the original patch, new pseudocode is below:
![image](https://github.com/acidanthera/BrcmPatchRAM/assets/16227538/b48f7f9e-bdae-4c0a-8461-ddc34992e886)

I simply update the patch, fill `nop` instruction to escape the jump condition.

by the way, `0x77, 0x1A` is a relative jump, hardcode the offset `0x1A` is also acceptable?