### PR TITLE
BluetoolFixup: Add another patch to skip Internal Bluetooth Controller NVRAM checking.

### DIFF
--- a/BrcmPatchRAM/BlueToolFixup.cpp
+++ b/BrcmPatchRAM/BlueToolFixup.cpp
@@ -123,6 +123,30 @@ static const uint8_t kBadChipsetCheckPatched13_3[] =
     0x90, 0x90
 };
 
+static const uint8_t kSkipInternalControllerNVRAMCheck13_3[] =
+{
+    0x41, 0x80, 0x00, 0x01, // xor     r15b, 1
+    0x75, 0x00,             // jnz     short
+    0x84, 0xDB,             // test    bl, bl
+    0x75, 0x00              // jnz     short
+};
+
+static const uint8_t kSkipInternalControllerNVRAMCheckMask13_3[] =
+{
+    0xFF, 0xFF, 0x00, 0xFF,
+    0xFF, 0x00,
+    0xFF, 0xFF,
+    0xFF, 0x00
+};
+
+static const uint8_t kSkipInternalControllerNVRAMCheckPatched13_3[] =
+{
+    0x90, 0x90, 0x90, 0x90,
+    0x90, 0x90,
+    0x90, 0x90,
+    0x90, 0x90
+};
+
 static bool shouldPatchBoardId = false;
 static bool shouldPatchAddress = false;
 
@@ -188,6 +212,7 @@ static void patched_cs_validate_page(vnode_t vp, memory_object_t pager, memory_o
             searchAndPatch(data, PAGE_SIZE, path, kVendorCheckOriginal, kVendorCheckPatched);
             searchAndPatch(data, PAGE_SIZE, path, kBadChipsetCheckOriginal, kBadChipsetCheckPatched);
             searchAndPatch(data, PAGE_SIZE, path, kBadChipsetCheckOriginal13_3, kBadChipsetCheckPatched13_3);
+            searchAndPatchWithMask(data, PAGE_SIZE, path, kSkipInternalControllerNVRAMCheck13_3, sizeof(kSkipInternalControllerNVRAMCheck13_3), kSkipInternalControllerNVRAMCheckMask13_3, sizeof(kSkipInternalControllerNVRAMCheckMask13_3), kSkipInternalControllerNVRAMCheckPatched13_3, sizeof(kSkipInternalControllerNVRAMCheckPatched13_3), nullptr, 0);
             if (shouldPatchBoardId)
                 searchAndPatch(data, PAGE_SIZE, path, boardIdsWithUSBBluetooth[0], kBoardIdSize, BaseDeviceInfo::get().boardIdentifier, kBoardIdSize);
             if (shouldPatchAddress)


### PR DESCRIPTION
Hi,
From Ventura 13.4(maybe), Apple adds two NVRAM check:
1. `bluetoothInternalControllerInfo` : which stores the internal Bluetooth controller(always real mac)'s mac address.
2. `bluetoothExternalDongleFailed`:  which to indicates that the bluetoothd had failure initialization with external bluetooth Dongle(Stupid design).

original code:
![image](https://github.com/acidanthera/BrcmPatchRAM/assets/16227538/3a7899f8-37e2-4898-b3c4-15181d9de5fb)
![image](https://github.com/acidanthera/BrcmPatchRAM/assets/16227538/ad1bf901-700f-4c6b-ba8c-e4ecc44d08bb)

after patched:
![image](https://github.com/acidanthera/BrcmPatchRAM/assets/16227538/f4bb0fb4-51f0-4eae-a97b-d54cd43adb2b)
![image](https://github.com/acidanthera/BrcmPatchRAM/assets/16227538/be687693-c23b-4a99-8bb2-b3b7049e5cbc)


these two section are created by bluetoothd self, but if the user clean/reset NVRAM, then the bluetoothd will not treat the device as external Dongle at all, so it is foreseeable that Bluetooth will not be able to be used.

Here I make a patch to skip these two conditions, and seems working so well.
